### PR TITLE
seeds restart id count, unecessary tag removed

### DIFF
--- a/src/db/seeds/event_tags.js
+++ b/src/db/seeds/event_tags.js
@@ -9,7 +9,7 @@ let event_tags = [
   { name: 'biking' },
   { name: 'weight-lifting' },
   { name: 'calisthenics' },
-  { name: 'orgy' },
+  { name: 'coaching' },
   { name: 'jogging' },
   { name: 'small' },
   { name: 'massive' },
@@ -17,6 +17,7 @@ let event_tags = [
 ];
 exports.seed = async function (knex) {
   // Deletes ALL existing entries
+  await knex.raw('ALTER SEQUENCE event_tags_id_seq RESTART WITH 1')
   await knex('event_tags').del();
   await knex('event_tags').insert(event_tags);
 };

--- a/src/db/seeds/event_tags_events.js
+++ b/src/db/seeds/event_tags_events.js
@@ -13,23 +13,23 @@ let event_tags_events = [ {
 },
 {
   event_id : 2,
-  event_tag_id : 1
-},
-{
-  event_id : 2,
-  event_tag_id : 3
-},
-{
-  event_id : 2,
-  event_tag_id : 4
-},
-{
-  event_id : 3,
   event_tag_id : 6
 },
 {
+  event_id : 2,
+  event_tag_id : 8
+},
+{
   event_id : 3,
-  event_tag_id : 10
+  event_tag_id : 3
+},
+{
+  event_id : 3,
+  event_tag_id : 2
+},
+{
+  event_id : 3,
+  event_tag_id : 2
 },]
 exports.seed = async function(knex) {
   // Deletes ALL existing entries

--- a/src/db/seeds/events.js
+++ b/src/db/seeds/events.js
@@ -14,7 +14,7 @@ let events    =      [{
 },
 
 { 
-  title: 'Naked Cardio',
+  title: 'Intense Cardio',
   location: 'Prospect Park',
   description: '😏😏😏',
   date: '2024-02-01T15:30:00Z', 
@@ -32,6 +32,7 @@ let events    =      [{
 ]
 exports.seed = async function(knex) {
   // Deletes ALL existing entries
+  await knex.raw('ALTER SEQUENCE events_id_seq RESTART WITH 1')
   await knex('events').del()
   await knex('events').insert(events);
 };


### PR DESCRIPTION
Seed files with tables with keys used as foreign keys now have there id restarted on 1
 Removed unnecessary tag